### PR TITLE
Allow debugging of a specific process name

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -25,7 +25,7 @@ paths:
       tags:
       - "debugattachment"
       summary: "Request squash to attach to a running container."
-      description: > 
+      description: >
                       A debug attachment instructs squash to attach to a container. Debug attachment is made of
                         - image: The container image we are debugging. this is used for extra validation, as placing breakpoints on the wrong binary can lead to unexpected results. if not provided huerisrtics will be used to identify it.
                         - debugger: Type of debugger to use. "dlv" and "gdb" are supported now.
@@ -58,7 +58,7 @@ paths:
     get:
       tags:
       - "debugattachment"
-      summary: "Return all debug attachment" 
+      summary: "Return all debug attachment"
       description: "Return all debug attachment"
       operationId: "getDebugAttachments"
       parameters:
@@ -110,7 +110,7 @@ paths:
       tags:
       - "debugattachment"
       summary: "Modify an existing attachment."
-      description: > 
+      description: >
                       Modify an existing attachment.
       operationId: "patchDebugAttachment"
       consumes:
@@ -147,7 +147,7 @@ paths:
     delete:
       tags:
       - "debugattachment"
-      summary: "Delete a debug attachment" 
+      summary: "Delete a debug attachment"
       description: "Delete a debug attachment. be careful not to delete on during attaching phase."
       operationId: "deleteDebugAttachment"
       parameters:
@@ -168,7 +168,7 @@ paths:
     get:
       tags:
       - "debugattachment"
-      summary: "Return a debug attachment" 
+      summary: "Return a debug attachment"
       description: "Return a debug attachment"
       operationId: "getDebugAttachment"
       parameters:
@@ -192,7 +192,7 @@ paths:
     get:
       tags:
       - "debugrequest"
-      summary: "Return all debug request" 
+      summary: "Return all debug request"
       description: "Return all debug requests"
       operationId: "getDebugRequests"
       responses:
@@ -207,7 +207,7 @@ paths:
     post:
       tags:
       - "debugrequest"
-      summary: "Return a debug attachment" 
+      summary: "Return a debug attachment"
       description: "Return a debug attachment"
       operationId: "createDebugRequest"
       consumes:
@@ -230,7 +230,7 @@ paths:
     get:
       tags:
       - "debugrequest"
-      summary: "Get a debug request" 
+      summary: "Get a debug request"
       description: "Get a debug request"
       operationId: "getDebugRequest"
       parameters:
@@ -249,7 +249,7 @@ paths:
     delete:
       tags:
       - "debugrequest"
-      summary: "Delete a debug request" 
+      summary: "Delete a debug request"
       description: "Delete a debug request."
       operationId: "deleteDebugRequest"
       parameters:
@@ -290,6 +290,8 @@ definitions:
         type: string
       image:
         type: string
+      process_name:
+        type: string
       node:
         type: string
       match_request:
@@ -327,6 +329,9 @@ definitions:
         type: string
       debugger:
         type: string
+      process_name:
+        type: string
+
 
   DebugRequestStatus:
     type: object

--- a/cmd/squash-cli/debug-container.go
+++ b/cmd/squash-cli/debug-container.go
@@ -17,6 +17,7 @@ import (
 func init() {
 
 	namespace := "default"
+	processName := ""
 
 	var debugContainerCmd = &cobra.Command{
 		Use:   "debug-container image pod container [type]",
@@ -50,8 +51,9 @@ func init() {
 						Pod:       pod,
 						Container: container,
 					},
-					Image:    image,
-					Debugger: debuggertype,
+					ProcessName: processName,
+					Image:       image,
+					Debugger:    debuggertype,
 				},
 			}
 
@@ -81,6 +83,7 @@ func init() {
 	}
 
 	debugContainerCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace the pod belongs to")
+	debugContainerCmd.Flags().StringVarP(&processName, "processName", "p", "", "Process name to debug (defaults to the first running process)")
 
 	RootCmd.AddCommand(debugContainerCmd)
 

--- a/cmd/squash-cli/debug-request.go
+++ b/cmd/squash-cli/debug-request.go
@@ -13,12 +13,14 @@ import (
 
 func init() {
 
+	processName := ""
 	var debugServiceCmd = &cobra.Command{
 		Use:   "debug-request image debugger",
 		Short: "debug-request adds a debug request.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			image := ""
 			debugger := ""
+
 			switch len(args) {
 			case 2:
 				image, debugger = args[0], args[1]
@@ -28,8 +30,9 @@ func init() {
 			// parse
 			dbgrequest := models.DebugRequest{
 				Spec: &models.DebugRequestSpec{
-					Debugger: &debugger,
-					Image:    &image,
+					Debugger:    &debugger,
+					ProcessName: processName,
+					Image:       &image,
 				},
 			}
 
@@ -60,6 +63,8 @@ func init() {
 			return nil
 		},
 	}
+
+	debugServiceCmd.Flags().StringVarP(&processName, "processName", "p", "", "Process name to debug (defaults to the first running process)")
 
 	RootCmd.AddCommand(debugServiceCmd)
 

--- a/pkg/models/debug_attachment_spec.go
+++ b/pkg/models/debug_attachment_spec.go
@@ -31,6 +31,9 @@ type DebugAttachmentSpec struct {
 
 	// node
 	Node string `json:"node,omitempty"`
+
+	// process name
+	ProcessName string `json:"process_name,omitempty"`
 }
 
 // Validate validates this debug attachment spec

--- a/pkg/models/debug_request_spec.go
+++ b/pkg/models/debug_request_spec.go
@@ -24,6 +24,9 @@ type DebugRequestSpec struct {
 	// image
 	// Required: true
 	Image *string `json:"image"`
+
+	// process name
+	ProcessName string `json:"process_name,omitempty"`
 }
 
 // Validate validates this debug request spec

--- a/pkg/platforms/interface.go
+++ b/pkg/platforms/interface.go
@@ -20,7 +20,7 @@ type ContainerLocator interface {
 /// Runs in the squash client:
 /// Information for the squash client to be able to connect debugger to the process
 type ContainerInfo struct {
-	Pid  int
+	Pids []int
 	Name string
 }
 

--- a/pkg/platforms/kubernetes/client.go
+++ b/pkg/platforms/kubernetes/client.go
@@ -3,10 +3,8 @@ package kubernetes
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -127,35 +125,7 @@ func (c *CRIContainerProcess) GetContainerInfo(maincontext context.Context, atta
 	}
 
 	log.WithField("potentialpids", potentialpids).Info("found some pids")
-	pid, err := FindFirstProcess(potentialpids)
-	if err != nil {
-		log.WithField("err", err).Warn("FindFirstProcess error")
-		return nil, err
-	}
-
-	return &platforms.ContainerInfo{Pid: pid, Name: ka.Pod}, nil
-}
-
-func FindFirstProcess(pids []int) (int, error) {
-	minpid := 0
-	var mintime *time.Time
-	for _, pid := range pids {
-		p := filepath.Join("/proc", fmt.Sprintf("%d", pid), "exe")
-		n, err := os.Stat(p)
-		if err != nil {
-			continue
-		}
-		t := n.ModTime()
-		if (mintime == nil) || t.Before(*mintime) {
-			mintime = &t
-			minpid = pid
-		}
-	}
-
-	if minpid == 0 {
-		return 0, errors.New("no process found")
-	}
-	return minpid, nil
+	return &platforms.ContainerInfo{Pids: potentialpids, Name: ka.Pod}, nil
 }
 
 func FindPidsInNS(inod uint64, ns string) ([]int, error) {

--- a/pkg/restapi/embedded_spec.go
+++ b/pkg/restapi/embedded_spec.go
@@ -40,7 +40,6 @@ func init() {
         ],
         "summary": "Return all debug attachment",
         "operationId": "getDebugAttachments",
-        "security": null,
         "parameters": [
           {
             "type": "boolean",
@@ -115,7 +114,6 @@ func init() {
         ],
         "summary": "Request squash to attach to a running container.",
         "operationId": "addDebugAttachment",
-        "security": null,
         "parameters": [
           {
             "description": "DebugAttachment object",
@@ -157,7 +155,6 @@ func init() {
         ],
         "summary": "Return a debug attachment",
         "operationId": "getDebugAttachment",
-        "security": null,
         "parameters": [
           {
             "type": "string",
@@ -192,7 +189,6 @@ func init() {
         ],
         "summary": "Delete a debug attachment",
         "operationId": "deleteDebugAttachment",
-        "security": null,
         "parameters": [
           {
             "type": "string",
@@ -230,7 +226,6 @@ func init() {
         ],
         "summary": "Modify an existing attachment.",
         "operationId": "patchDebugAttachment",
-        "security": null,
         "parameters": [
           {
             "type": "string",
@@ -282,7 +277,6 @@ func init() {
         ],
         "summary": "Return all debug request",
         "operationId": "getDebugRequests",
-        "security": null,
         "responses": {
           "200": {
             "description": "OK",
@@ -311,7 +305,6 @@ func init() {
         ],
         "summary": "Return a debug attachment",
         "operationId": "createDebugRequest",
-        "security": null,
         "parameters": [
           {
             "description": "DebugRequest object",
@@ -341,7 +334,6 @@ func init() {
         ],
         "summary": "Get a debug request",
         "operationId": "getDebugRequest",
-        "security": null,
         "parameters": [
           {
             "type": "string",
@@ -370,7 +362,6 @@ func init() {
         ],
         "summary": "Delete a debug request",
         "operationId": "deleteDebugRequest",
-        "security": null,
         "parameters": [
           {
             "type": "string",
@@ -439,6 +430,9 @@ func init() {
         },
         "node": {
           "type": "string"
+        },
+        "process_name": {
+          "type": "string"
         }
       }
     },
@@ -487,6 +481,9 @@ func init() {
           "type": "string"
         },
         "image": {
+          "type": "string"
+        },
+        "process_name": {
           "type": "string"
         }
       }

--- a/pkg/server/server-rest.go
+++ b/pkg/server/server-rest.go
@@ -91,6 +91,16 @@ func (r *RestHandler) DebugattachmentAddDebugAttachmentHandler(params debugattac
 			dbgattachment.Spec.Debugger = *dr.Spec.Debugger
 		}
 
+		if dbgattachment.Spec.ProcessName != "" && dbgattachment.Spec.ProcessName != dr.Spec.ProcessName {
+			log.WithFields(
+				log.Fields{
+					"dbgattachment":                  dbgattachment,
+					"dbgattachment.Spec.ProcessName": dbgattachment.Spec.ProcessName,
+					"dr.Spec.ProcessName":            dr.Spec.ProcessName,
+				}).Warning("debug attachment processName conflict")
+		}
+		dbgattachment.Spec.ProcessName = dr.Spec.ProcessName
+
 		// we found a matching request - we can save now.
 		r.saveDebugAttachment(dbgattachment)
 
@@ -122,6 +132,7 @@ func (r *RestHandler) findUnboundDebugRequest(dbgattachment *models.DebugAttachm
 		if dr.Spec.Image == nil || *dr.Spec.Image != dbgattachment.Spec.Image {
 			continue
 		}
+
 		// logical NOT XOR
 		if (dr.Spec.Debugger == nil) == (dbgattachment.Spec.Debugger == "") {
 			continue

--- a/test/e2e/session_test.go
+++ b/test/e2e/session_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Single debug mode", func() {
 			fmt.Println("error creating ns", err)
 			panic(err)
 		}
-		fmt.Printf("create sutff %v \n", kubectl)
+		fmt.Printf("creating environment %v \n", kubectl)
 
 		if err := kubectl.CreateLocalRoles("../../target/kubernetes/squash-server.yml"); err != nil {
 			panic(err)
@@ -70,6 +70,19 @@ var _ = Describe("Single debug mode", func() {
 	})
 
 	AfterEach(func() {
+		var p *v1.Pod
+		for _, v := range MicroservicePods {
+			p = v
+			break
+		}
+
+		logs, _ := kubectl.Logs(ServerPod.ObjectMeta.Name)
+		fmt.Fprintln(GinkgoWriter, "server logs:")
+		fmt.Fprintln(GinkgoWriter, string(logs))
+		clogs, _ := kubectl.Logs(ClientPods[p.Spec.NodeName].ObjectMeta.Name)
+		fmt.Fprintln(GinkgoWriter, "client logs:")
+		fmt.Fprintln(GinkgoWriter, string(clogs))
+
 		kubectl.DeleteNS()
 
 	})
@@ -85,7 +98,7 @@ var _ = Describe("Single debug mode", func() {
 
 			container := p.Spec.Containers[0]
 
-			dbgattachment, err := squash.Attach(container.Image, p.ObjectMeta.Name, container.Name, "dlv")
+			dbgattachment, err := squash.Attach(container.Image, p.ObjectMeta.Name, container.Name, "", "dlv")
 			if err != nil {
 				logs, _ := kubectl.Logs(ServerPod.ObjectMeta.Name)
 				fmt.Println(string(logs))
@@ -94,18 +107,54 @@ var _ = Describe("Single debug mode", func() {
 			time.Sleep(time.Second)
 
 			updatedattachment, err := squash.Wait(dbgattachment.Metadata.Name)
-			if err != nil {
-				logs, _ := kubectl.Logs(ServerPod.ObjectMeta.Name)
-				fmt.Println("server logs:")
-				fmt.Println(string(logs))
-				clogs, _ := kubectl.Logs(ClientPods[p.Spec.NodeName].ObjectMeta.Name)
-				fmt.Println("client logs:")
-				fmt.Println(string(clogs))
-				panic(err)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedattachment.Status.DebugServerAddress).ToNot(BeEmpty())
+		})
+		It("should get a debug server endpoint, specific process", func() {
+
+			var p *v1.Pod
+			for _, v := range MicroservicePods {
+				p = v
+				break
 			}
 
-			Expect(updatedattachment.Status.DebugServerAddress).ToNot(BeEmpty())
+			container := p.Spec.Containers[0]
 
+			dbgattachment, err := squash.Attach(container.Image, p.ObjectMeta.Name, container.Name, "service1", "dlv")
+			if err != nil {
+				logs, _ := kubectl.Logs(ServerPod.ObjectMeta.Name)
+				fmt.Println(string(logs))
+				panic(err)
+			}
+			time.Sleep(time.Second)
+
+			updatedattachment, err := squash.Wait(dbgattachment.Metadata.Name)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedattachment.Status.DebugServerAddress).ToNot(BeEmpty())
+		})
+		It("should get a debug server endpoint, specific process that doesn't exist", func() {
+
+			var p *v1.Pod
+			for _, v := range MicroservicePods {
+				p = v
+				break
+			}
+
+			container := p.Spec.Containers[0]
+
+			dbgattachment, err := squash.Attach(container.Image, p.ObjectMeta.Name, container.Name, "processNameDoesntExist", "dlv")
+			if err != nil {
+				logs, _ := kubectl.Logs(ServerPod.ObjectMeta.Name)
+				fmt.Println(string(logs))
+				panic(err)
+			}
+			time.Sleep(time.Second)
+
+			updatedattachment, err := squash.Wait(dbgattachment.Metadata.Name)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedattachment.Status.State).To(Equal("error"))
 		})
 	})
 


### PR DESCRIPTION
This helps for situations where the first process spawned isn't the one we'd like to debug. Common causes are proxy launchers (shell scripts for Java etc).