### PR TITLE
Update README.md to list Intellij as supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ An annotated version of this demo can be found [here](https://youtu.be/5aNPfwVvL
  
 ## Supported IDEs:
  - [VS Code](https://github.com/solo-io/squash-vscode)
+ - [Intellij](https://github.com/solo-io/squash-intellij) (currently Java/Kubernetes only)
 
 *We are looking for community help to add support for more debuggers, platforms and IDEs.*
 
@@ -89,7 +90,6 @@ An annotated version of this demo can be found [here](https://youtu.be/5aNPfwVvL
   
 **IDEs**
   - [Eclipse](https://eclipse.org/ide/)
-  - [Intellij](https://www.jetbrains.com/idea/)
 
 
 Squash is still experimental! APIs and compatibility are subject to change. We are looking for community support to help identify potential bugs and compatibility issues. Please open a Github issue for any problems you may experience, and join us on our [slack channel](http://slack.solo.io)


### PR DESCRIPTION
I noticed the Intellij plugin was available (awesome!) and listed as 1.0 in Intellij. I figured you might want this updated here, but maybe it is too early to call it "supported" :)