### PR TITLE
fix: add squash namespace to ClusterRoleBindings

### DIFF
--- a/contrib/kubernetes/squash-server.yml
+++ b/contrib/kubernetes/squash-server.yml
@@ -47,8 +47,10 @@ metadata:
   name: squash-full-control-crds
 subjects:
 - kind: ServiceAccount
+  namespace: squash
   name: squash-server
 - kind: ServiceAccount
+  namespace: squash
   name: default
 roleRef:
   kind: ClusterRole

--- a/contrib/kubernetes/squash-server.yml.tmpl
+++ b/contrib/kubernetes/squash-server.yml.tmpl
@@ -47,8 +47,10 @@ metadata:
   name: squash-full-control-crds
 subjects:
 - kind: ServiceAccount
+  namespace: squash
   name: squash-server
 - kind: ServiceAccount
+  namespace: squash
   name: default
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
I am using k8s version 1.11.2 and when I tried to create the squash server with this command:
`kubectl create -f https://raw.githubusercontent.com/solo-io/squash/master/contrib/kubernetes/squash-server.yml`

I get the following error:
```
The ClusterRoleBinding "squash-full-control-crds" is invalid:
* subjects[0].namespace: Required value
* subjects[1].namespace: Required value
```

Adding `namespace: squash` to both `ServiceAccount` elements has fixed the issue