### PR TITLE
script for pulling release shas, verbose flag in vscode extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,13 @@ vendor/*
 site/
 
 .vscode/*
+
+editor/vscode/binaries/
+
+# temp java example files
+contrib/example/service2-java/.classpath
+contrib/example/service2-java/.project
+contrib/example/service2-java/.settings/
+
+# temp go example files
+contrib/example/service1/.vscode/settings.json

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ clean:
 generatecode:
 	mkdir -p $(OUTPUT_DIR)
 	go run cmd/generate-code/main.go
-	# go run cmd/generate-docs/main.go
+	go run cmd/generate-docs/main.go
 	gofmt -w ci cmd pkg test
 	goimports -w ci cmd pkg test
 

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ clean:
 generatecode:
 	mkdir -p $(OUTPUT_DIR)
 	go run cmd/generate-code/main.go
-	go run cmd/generate-docs/main.go
+	# go run cmd/generate-docs/main.go # Re-enable this when squashctl does not create resources on init
 	gofmt -w ci cmd pkg test
 	goimports -w ci cmd pkg test
 

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -3,6 +3,6 @@
 # Normally, the vscode extension config file is generated during the release process
 # If you are testing changes locally and want to set the values to a particular version
 # use this make target
-.PHONY: extension
-extension:
+.PHONY: extension-json
+extension-json:
 	go run ci/generate-extension-resources.go ${VERSION}

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -1,0 +1,8 @@
+
+
+# Normally, the vscode extension config file is generated during the release process
+# If you are testing changes locally and want to set the values to a particular version
+# use this make target
+.PHONY: extension
+extension:
+	go run ci/generate-extension-resources.go ${VERSION}

--- a/changelog/v0.5.4/quiet-demos.yaml
+++ b/changelog/v0.5.4/quiet-demos.yaml
@@ -1,4 +1,0 @@
-changelog:
-- type: FIX
-  description: When deploying demos, just print app type, not deployment details.
-  issueLink: https://github.com/solo-io/squash/issues/125

--- a/changelog/v0.5.4/quiet-demos.yaml
+++ b/changelog/v0.5.4/quiet-demos.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: FIX
+  description: When deploying demos, just print app type, not deployment details.
+  issueLink: https://github.com/solo-io/squash/issues/125

--- a/changelog/v0.5.4/verbose-extension-flag.yaml
+++ b/changelog/v0.5.4/verbose-extension-flag.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: NEW_FEATURE
+  description: Add optional verbose flag to vscode extension for self-diagnostics.
+  issueLink: https://github.com/solo-io/squash/issues/141
+- type: NON_USER_FACING
+  description: Script for pulling release shas from GitHub.

--- a/changelog/v0.5.4/verbose-extension-flag.yaml
+++ b/changelog/v0.5.4/verbose-extension-flag.yaml
@@ -7,3 +7,6 @@ changelog:
 - type: FIX
   description: When deploying demos, just print app type, not deployment details.
   issueLink: https://github.com/solo-io/squash/issues/125
+- type: FIX
+  description: Clean up test resources to improve CI stability.
+  issueLink: https://github.com/solo-io/squash/issues/140

--- a/changelog/v0.5.4/verbose-extension-flag.yaml
+++ b/changelog/v0.5.4/verbose-extension-flag.yaml
@@ -4,3 +4,6 @@ changelog:
   issueLink: https://github.com/solo-io/squash/issues/141
 - type: NON_USER_FACING
   description: Script for pulling release shas from GitHub.
+- type: FIX
+  description: When deploying demos, just print app type, not deployment details.
+  issueLink: https://github.com/solo-io/squash/issues/125

--- a/ci/generate-extension-resources.go
+++ b/ci/generate-extension-resources.go
@@ -8,10 +8,6 @@ import (
 	"github.com/solo-io/squash/ci/internal/extconfig"
 )
 
-// This program does three things:
-// 1. reads and hashes these files
-// 2. modifies the version field of this file
-// 3. produces this file
 func main() {
 
 	ctx := context.TODO()
@@ -20,7 +16,5 @@ func main() {
 	}
 	version := os.Args[1]
 
-	extconfig.MustPrepareReleaseJsPackage(ctx, version)
-	extconfig.MustPrepareReleaseConfigFile(ctx, version)
-
+	extconfig.MustCreateDevResources(ctx, version)
 }

--- a/ci/internal/extconfig/common.go
+++ b/ci/internal/extconfig/common.go
@@ -31,12 +31,12 @@ const (
 	outputLinux  = "_output/squashctl-linux"
 	outputDarwin = "_output/squashctl-darwin"
 
+	// This file interfaces the extension with the VS-Code marketplace
 	jsPackage = "editor/vscode/package.json"
 
+	// This file tells the vscode extension about the latest release of squashctl
 	squashConfig = "editor/vscode/src/squash.json"
 )
-
-// (End summary of functionality)
 
 const (
 	extensionBaseName = "squashctl"

--- a/ci/internal/extconfig/common.go
+++ b/ci/internal/extconfig/common.go
@@ -1,0 +1,67 @@
+package extconfig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/solo-io/go-utils/contextutils"
+)
+
+type SquashSpec struct {
+	Version  string   `json:"version"`
+	BaseName string   `json:"baseName"`
+	Binaries Binaries `json:"binaries"`
+}
+
+type Binaries struct {
+	Win32  string `json:"win32"`
+	Linux  string `json:"linux"`
+	Darwin string `json:"darwin"`
+}
+
+const (
+	osShaIdWin32  = "windows.exe"
+	osShaIdLinux  = "linux"
+	osShaIdDarwin = "darwin"
+
+	outputWin32  = "_output/squashctl-windows.exe"
+	outputLinux  = "_output/squashctl-linux"
+	outputDarwin = "_output/squashctl-darwin"
+
+	jsPackage = "editor/vscode/package.json"
+
+	squashConfig = "editor/vscode/src/squash.json"
+)
+
+// (End summary of functionality)
+
+const (
+	extensionBaseName = "squashctl"
+)
+
+var (
+	jsPackageVersionLineMatch *regexp.Regexp
+)
+
+func init() {
+	jsPackageVersionLineMatch = regexp.MustCompile("THIS_VALUE_WILL_BE_REPLACED_BY_BUILD_SCRIPT")
+}
+
+func mustGenerateConfigFile(ctx context.Context, squashSpec SquashSpec) {
+	json, err := json.MarshalIndent(squashSpec, "", "  ")
+	lo := contextutils.LoggerFrom(ctx)
+	if err != nil {
+		lo.Fatal(err)
+	}
+	configOut, err := os.Create(squashConfig)
+	if err != nil {
+		lo.Fatal(err)
+	}
+	defer configOut.Close()
+	if _, err := fmt.Fprintf(configOut, string(json)); err != nil {
+		lo.Fatal(err)
+	}
+}

--- a/ci/internal/extconfig/dev.go
+++ b/ci/internal/extconfig/dev.go
@@ -1,0 +1,50 @@
+package extconfig
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/solo-io/go-utils/contextutils"
+)
+
+func MustCreateDevResources(ctx context.Context, version string) {
+	bins := Binaries{
+		Linux:  MustDownloadSha(ctx, version, osShaIdLinux),
+		Darwin: MustDownloadSha(ctx, version, osShaIdDarwin),
+		Win32:  MustDownloadSha(ctx, version, osShaIdWin32),
+	}
+	squashSpec := SquashSpec{
+		Version:  version,
+		BaseName: extensionBaseName,
+		Binaries: bins,
+	}
+	mustGenerateConfigFile(ctx, squashSpec)
+}
+
+func MustDownloadSha(ctx context.Context, version, osId string) string {
+	url := fmt.Sprintf("https://github.com/solo-io/squash/releases/download/%v/squashctl-%v.sha256", version, osId)
+	str := ""
+	if err := getFileContent(url, &str); err != nil {
+		contextutils.LoggerFrom(ctx).Fatal(err)
+	}
+	return str
+}
+
+func getFileContent(url string, str *string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	*str = buf.String()
+	return nil
+}

--- a/ci/internal/extconfig/release.go
+++ b/ci/internal/extconfig/release.go
@@ -1,0 +1,80 @@
+package extconfig
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/solo-io/go-utils/contextutils"
+)
+
+func MustPrepareReleaseJsPackage(ctx context.Context, version string) {
+	lo := contextutils.LoggerFrom(ctx)
+	file, err := os.Open(jsPackage)
+	if err != nil {
+		lo.Fatal(err)
+	}
+	scanner := bufio.NewScanner(file)
+	out := ""
+	for scanner.Scan() {
+		if jsPackageVersionLineMatch.MatchString(scanner.Text()) {
+			out += fmt.Sprintf(`  "version": "%v",%v`, version, "\n")
+		} else {
+			out += scanner.Text() + "\n"
+		}
+	}
+	file.Close()
+	writeOut, err := os.Create(jsPackage)
+	if err != nil {
+		lo.Fatal(err)
+	}
+	defer writeOut.Close()
+	// must be explicit with the format string to prevent accidental substitutions
+	if _, err := fmt.Fprintf(writeOut, "%v", out); err != nil {
+		lo.Fatal(err)
+	}
+}
+
+func MustPrepareReleaseConfigFile(ctx context.Context, version string) {
+	bins := Binaries{
+		Linux:  MustGetSha(ctx, outputLinux),
+		Darwin: MustGetSha(ctx, outputDarwin),
+		Win32:  MustGetSha(ctx, outputWin32),
+	}
+
+	squashSpec := SquashSpec{
+		Version:  version,
+		BaseName: extensionBaseName,
+		Binaries: bins,
+	}
+	mustGenerateConfigFile(ctx, squashSpec)
+}
+
+func MustGetSha(ctx context.Context, path string) string {
+	file, err := os.Open(path)
+	defer file.Close()
+	if err != nil {
+		contextutils.LoggerFrom(ctx).Fatal(err)
+	}
+	sha, err := GenerateSoloSha256(file)
+	if err != nil {
+		contextutils.LoggerFrom(ctx).Fatal(err)
+	}
+	return sha
+}
+
+// TODO(mitchdraft) get this from go-utils
+// GenerateSoloSha256 produces a sha256 hash of the given file in a standard way
+// for use in Solo.io's build artifact management.
+func GenerateSoloSha256(file *os.File) (string, error) {
+	h := sha256.New()
+	if _, err := io.Copy(h, file); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%v %v\n", hex.EncodeToString(h.Sum(nil)), filepath.Base(file.Name())), nil
+}

--- a/ci/internal/extconfig/release.go
+++ b/ci/internal/extconfig/release.go
@@ -21,12 +21,17 @@ func MustPrepareReleaseJsPackage(ctx context.Context, version string) {
 	}
 	scanner := bufio.NewScanner(file)
 	out := ""
+	updatedVersion := false
 	for scanner.Scan() {
 		if jsPackageVersionLineMatch.MatchString(scanner.Text()) {
 			out += fmt.Sprintf(`  "version": "%v",%v`, version, "\n")
+			updatedVersion = true
 		} else {
 			out += scanner.Text() + "\n"
 		}
+	}
+	if !updatedVersion {
+		lo.Fatal(fmt.Errorf("Did not find version substitution string in package.json, version %v has not been applied", version))
 	}
 	file.Close()
 	writeOut, err := os.Create(jsPackage)

--- a/contrib/example/service1/.vscode/settings.json
+++ b/contrib/example/service1/.vscode/settings.json
@@ -1,4 +1,0 @@
-// Place your settings in this file to overwrite default and user settings.
-{
-    "vs-squash.remotePath": "/home/yuval/go/src/github.com/solo-io/squash/contrib/example/service1/"
-}

--- a/docs/cli/squashctl.md
+++ b/docs/cli/squashctl.md
@@ -36,7 +36,7 @@ squashctl [flags]
       --no-guess-debugger          don't auto detect debugger to use
       --no-guess-pod               don't auto detect pod to use
       --pod string                 Pod to debug
-      --squash-namespace string    the namespace where squash resourcea will be deployed (default: squash-debugger) (default "squash-debugger")
+      --squash-namespace string    the namespace where squash resources will be deployed (default: squash-debugger) (default "squash-debugger")
       --timeout int                timeout in seconds to wait for debug pod to be ready (default 300)
 ```
 

--- a/docs/cli/squashctl_completion.md
+++ b/docs/cli/squashctl_completion.md
@@ -68,7 +68,7 @@ squashctl completion SHELL [flags]
       --no-guess-debugger          don't auto detect debugger to use
       --no-guess-pod               don't auto detect pod to use
       --pod string                 Pod to debug
-      --squash-namespace string    the namespace where squash resourcea will be deployed (default: squash-debugger) (default "squash-debugger")
+      --squash-namespace string    the namespace where squash resources will be deployed (default: squash-debugger) (default "squash-debugger")
       --timeout int                timeout in seconds to wait for debug pod to be ready (default 300)
 ```
 

--- a/docs/cli/squashctl_deploy.md
+++ b/docs/cli/squashctl_deploy.md
@@ -32,7 +32,7 @@ deploy squash or a demo microservice
       --no-guess-debugger          don't auto detect debugger to use
       --no-guess-pod               don't auto detect pod to use
       --pod string                 Pod to debug
-      --squash-namespace string    the namespace where squash resourcea will be deployed (default: squash-debugger) (default "squash-debugger")
+      --squash-namespace string    the namespace where squash resources will be deployed (default: squash-debugger) (default "squash-debugger")
       --timeout int                timeout in seconds to wait for debug pod to be ready (default 300)
 ```
 

--- a/docs/cli/squashctl_deploy_demo.md
+++ b/docs/cli/squashctl_deploy_demo.md
@@ -39,7 +39,7 @@ squashctl deploy demo [flags]
       --no-guess-debugger          don't auto detect debugger to use
       --no-guess-pod               don't auto detect pod to use
       --pod string                 Pod to debug
-      --squash-namespace string    the namespace where squash resourcea will be deployed (default: squash-debugger) (default "squash-debugger")
+      --squash-namespace string    the namespace where squash resources will be deployed (default: squash-debugger) (default "squash-debugger")
       --timeout int                timeout in seconds to wait for debug pod to be ready (default 300)
 ```
 

--- a/docs/cli/squashctl_deploy_squash.md
+++ b/docs/cli/squashctl_deploy_squash.md
@@ -37,7 +37,7 @@ squashctl deploy squash [flags]
       --no-guess-debugger          don't auto detect debugger to use
       --no-guess-pod               don't auto detect pod to use
       --pod string                 Pod to debug
-      --squash-namespace string    the namespace where squash resourcea will be deployed (default: squash-debugger) (default "squash-debugger")
+      --squash-namespace string    the namespace where squash resources will be deployed (default: squash-debugger) (default "squash-debugger")
       --timeout int                timeout in seconds to wait for debug pod to be ready (default 300)
 ```
 

--- a/docs/cli/squashctl_squash.md
+++ b/docs/cli/squashctl_squash.md
@@ -44,7 +44,7 @@ squashctl squash [flags]
       --no-guess-debugger          don't auto detect debugger to use
       --no-guess-pod               don't auto detect pod to use
       --pod string                 Pod to debug
-      --squash-namespace string    the namespace where squash resourcea will be deployed (default: squash-debugger) (default "squash-debugger")
+      --squash-namespace string    the namespace where squash resources will be deployed (default: squash-debugger) (default "squash-debugger")
       --timeout int                timeout in seconds to wait for debug pod to be ready (default 300)
 ```
 

--- a/docs/cli/squashctl_squash_delete.md
+++ b/docs/cli/squashctl_squash_delete.md
@@ -36,7 +36,7 @@ squashctl squash delete [flags]
       --no-guess-debugger          don't auto detect debugger to use
       --no-guess-pod               don't auto detect pod to use
       --pod string                 Pod to debug
-      --squash-namespace string    the namespace where squash resourcea will be deployed (default: squash-debugger) (default "squash-debugger")
+      --squash-namespace string    the namespace where squash resources will be deployed (default: squash-debugger) (default "squash-debugger")
       --timeout int                timeout in seconds to wait for debug pod to be ready (default 300)
 ```
 

--- a/docs/cli/squashctl_squash_status.md
+++ b/docs/cli/squashctl_squash_status.md
@@ -36,7 +36,7 @@ squashctl squash status [flags]
       --no-guess-debugger          don't auto detect debugger to use
       --no-guess-pod               don't auto detect pod to use
       --pod string                 Pod to debug
-      --squash-namespace string    the namespace where squash resourcea will be deployed (default: squash-debugger) (default "squash-debugger")
+      --squash-namespace string    the namespace where squash resources will be deployed (default: squash-debugger) (default "squash-debugger")
       --timeout int                timeout in seconds to wait for debug pod to be ready (default 300)
 ```
 

--- a/docs/cli/squashctl_utils.md
+++ b/docs/cli/squashctl_utils.md
@@ -42,7 +42,7 @@ squash utils list-attachments
       --no-guess-debugger          don't auto detect debugger to use
       --no-guess-pod               don't auto detect pod to use
       --pod string                 Pod to debug
-      --squash-namespace string    the namespace where squash resourcea will be deployed (default: squash-debugger) (default "squash-debugger")
+      --squash-namespace string    the namespace where squash resources will be deployed (default: squash-debugger) (default "squash-debugger")
       --timeout int                timeout in seconds to wait for debug pod to be ready (default 300)
 ```
 

--- a/docs/cli/squashctl_utils_delete-attachments.md
+++ b/docs/cli/squashctl_utils_delete-attachments.md
@@ -36,7 +36,7 @@ squashctl utils delete-attachments [flags]
       --no-guess-debugger          don't auto detect debugger to use
       --no-guess-pod               don't auto detect pod to use
       --pod string                 Pod to debug
-      --squash-namespace string    the namespace where squash resourcea will be deployed (default: squash-debugger) (default "squash-debugger")
+      --squash-namespace string    the namespace where squash resources will be deployed (default: squash-debugger) (default "squash-debugger")
       --timeout int                timeout in seconds to wait for debug pod to be ready (default 300)
 ```
 

--- a/docs/cli/squashctl_utils_delete-permissions.md
+++ b/docs/cli/squashctl_utils_delete-permissions.md
@@ -36,7 +36,7 @@ squashctl utils delete-permissions [flags]
       --no-guess-debugger          don't auto detect debugger to use
       --no-guess-pod               don't auto detect pod to use
       --pod string                 Pod to debug
-      --squash-namespace string    the namespace where squash resourcea will be deployed (default: squash-debugger) (default "squash-debugger")
+      --squash-namespace string    the namespace where squash resources will be deployed (default: squash-debugger) (default "squash-debugger")
       --timeout int                timeout in seconds to wait for debug pod to be ready (default 300)
 ```
 

--- a/docs/cli/squashctl_utils_delete-planks.md
+++ b/docs/cli/squashctl_utils_delete-planks.md
@@ -36,7 +36,7 @@ squashctl utils delete-planks [flags]
       --no-guess-debugger          don't auto detect debugger to use
       --no-guess-pod               don't auto detect pod to use
       --pod string                 Pod to debug
-      --squash-namespace string    the namespace where squash resourcea will be deployed (default: squash-debugger) (default "squash-debugger")
+      --squash-namespace string    the namespace where squash resources will be deployed (default: squash-debugger) (default "squash-debugger")
       --timeout int                timeout in seconds to wait for debug pod to be ready (default 300)
 ```
 

--- a/docs/cli/squashctl_utils_list-attachments.md
+++ b/docs/cli/squashctl_utils_list-attachments.md
@@ -36,7 +36,7 @@ squashctl utils list-attachments [flags]
       --no-guess-debugger          don't auto detect debugger to use
       --no-guess-pod               don't auto detect pod to use
       --pod string                 Pod to debug
-      --squash-namespace string    the namespace where squash resourcea will be deployed (default: squash-debugger) (default "squash-debugger")
+      --squash-namespace string    the namespace where squash resources will be deployed (default: squash-debugger) (default "squash-debugger")
       --timeout int                timeout in seconds to wait for debug pod to be ready (default 300)
 ```
 

--- a/editor/vscode/DEV.md
+++ b/editor/vscode/DEV.md
@@ -1,0 +1,37 @@
+# Notes for making changes to the vscode extension
+
+## Testing download feature
+
+### Background
+- This is a way to download a particular version of squashctl from github:
+```
+wget https://github.com/solo-io/squash/releases/download/v0.5.3/squashctl-darwin -O latestsquash
+```
+- When downloading through vscode, we want the url to have the format:
+```javascript
+let url = `https://github.com/solo-io/squash/releases/download/${version}/squashctl-${os-name}`
+```
+
+### Setup
+- since the release process writes the expected version and os-specific sha values, we need to set them explicitly, according to our development objective
+- this is the json file we need to generate:
+```json
+{
+  "version": <target_version>,
+  "baseName": "squashctl",
+  "binaries": {
+    "win32": <associated_win_hash>,
+    "linux": <associated_linux_hash>,
+    "darwin": <associated_darwin_hash>
+  }
+}
+```
+### How to get the hash values
+- you can download the shas like this:
+```
+wget https://github.com/solo-io/squash/releases/download/v0.5.3/squashctl-darwin.sha256
+```
+- Better, to get all shas and generate the full `editor/vscode/src/squash.json` file:
+```
+VERSION=<desired_released_version> make -f Makefile.dev extension-json
+```

--- a/editor/vscode/package.json
+++ b/editor/vscode/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "v0.0.999",
+  "version": "THIS_VALUE_WILL_BE_REPLACED_BY_BUILD_SCRIPT",
   "name": "squash",
   "displayName": "Squash",
   "description": "Debug your applications running on Kubernetes",

--- a/editor/vscode/package.json
+++ b/editor/vscode/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "THIS_VALUE_WILL_BE_REPLACED_BY_BUILD_SCRIPT",
+  "version": "v0.0.999",
   "name": "squash",
   "displayName": "Squash",
   "description": "Debug your applications running on Kubernetes",
@@ -61,6 +61,11 @@
           "type": "string",
           "default": null,
           "description": "Path of the source files in the remote executable."
+        },
+        "squash.verbose": {
+          "type": "boolean",
+          "default": false,
+          "description": "If set, prints diagnostic information related to the extension."
         }
       }
     },

--- a/editor/vscode/src/extension.ts
+++ b/editor/vscode/src/extension.ts
@@ -62,7 +62,6 @@ async function getremote(extPath: string): Promise<string> {
 
     let ks = getSquashctl();
 
-
     // exit this early until release is smoothed out
     if (fs.existsSync(execpath)) {
         let exechash = await hash(execpath);
@@ -182,6 +181,9 @@ class SquashExtension {
         }
         console.log("using squashctl from:");
         console.log(squashpath);
+        if ( get_conf_or("verbose", false) ) {
+            vscode.window.showInformationMessage("calling squashctl from: " + squashpath);
+        }
 
         if (!vscode.workspace.workspaceFolders) {
             throw new Error("no workspace folders");
@@ -476,7 +478,10 @@ interface SquashctlBinary {
 
 function createSquashctlBinary(os: string, checksum: string): SquashctlBinary {
     let link = "https://github.com/solo-io/squash/releases/download/" + getSquashInfo().version + "/" + getSquashInfo().baseName + "-" + os;
-    console.log("trying to dl from: " + link);
+    console.log("downloading from: " + link);
+    if ( get_conf_or("verbose", false) ) {
+        vscode.window.showInformationMessage("downloading from: " + link);
+    }
     return {
         link: "https://github.com/solo-io/squash/releases/download/" + getSquashInfo().version + "/" + getSquashInfo().baseName + "-" + os,
         checksum: checksum

--- a/pkg/demo/apps.go
+++ b/pkg/demo/apps.go
@@ -71,11 +71,10 @@ func DeployTemplate(cs *kubernetes.Clientset, namespace, appName, templateName, 
 		},
 	}
 
-	createdDeployment, err := cs.AppsV1().Deployments(namespace).Create(deployment)
+	_, err := cs.AppsV1().Deployments(namespace).Create(deployment)
 	if err != nil {
 		return err
 	}
-	fmt.Println(createdDeployment)
 
 	service := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -97,11 +96,11 @@ func DeployTemplate(cs *kubernetes.Clientset, namespace, appName, templateName, 
 			},
 		},
 	}
-	createdService, err := cs.CoreV1().Services(namespace).Create(service)
+	_, err = cs.CoreV1().Services(namespace).Create(service)
 	if err != nil {
 		return err
 	}
-	fmt.Println(createdService)
+	fmt.Printf("Deployed demo app %v in namespace %v\n", appName, namespace)
 
 	return nil
 }

--- a/pkg/squashctl/app.go
+++ b/pkg/squashctl/app.go
@@ -110,7 +110,7 @@ func applySquashFlags(cfg *config.Squash, f *pflag.FlagSet) {
 	f.StringVar(&cfg.Pod, "pod", "", "Pod to debug")
 	f.StringVar(&cfg.Container, "container", "", "Container to debug")
 	f.StringVar(&cfg.CRISock, "crisock", "/var/run/dockershim.sock", "The path to the CRI socket")
-	f.StringVar(&cfg.SquashNamespace, "squash-namespace", sqOpts.SquashNamespace, fmt.Sprintf("the namespace where squash resourcea will be deployed (default: %v)", options.SquashNamespace))
+	f.StringVar(&cfg.SquashNamespace, "squash-namespace", sqOpts.SquashNamespace, fmt.Sprintf("the namespace where squash resources will be deployed (default: %v)", options.SquashNamespace))
 }
 
 func initializeOptions(o *Options) error {

--- a/pkg/squashctl/util.go
+++ b/pkg/squashctl/util.go
@@ -204,12 +204,8 @@ func (o *Options) createPlankPermissions() error {
 	// need to create the permissions in the namespace of the target process
 	namespace := o.Squash.SquashNamespace
 
-	// create namespace. ignore errors as it most likely exists and will error
-	cs.CoreV1().Namespaces().Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
-
-	if _, err := cs.CoreV1().ServiceAccounts(namespace).Get(sqOpts.PlankServiceAccountName, metav1.GetOptions{}); err != nil {
+	if _, err := cs.CoreV1().Namespaces().Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}); err != nil {
 		if !errors.IsAlreadyExists(err) {
-			// service account already exists, no need to create it
 			return err
 		}
 	}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -7,7 +7,9 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	"github.com/solo-io/solo-kit/test/helpers"
+	sqOpts "github.com/solo-io/squash/pkg/options"
 	"github.com/solo-io/squash/test/testutils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"testing"
 )
@@ -26,4 +28,17 @@ var _ = BeforeSuite(func() {
 	seed := time.Now().UnixNano()
 	fmt.Printf("rand seed: %v\n", seed)
 	rand.Seed(seed)
+})
+
+// this list will be appened each time a test namespace is created
+var squashTestNamespaces = []string{sqOpts.SquashNamespace}
+var _ = AfterSuite(func() {
+	fmt.Println("clean up after test")
+	cs := MustGetClientset()
+	for _, ns := range squashTestNamespaces {
+		if err := cs.CoreV1().Namespaces().Delete(ns, &metav1.DeleteOptions{}); err != nil {
+			// don't fail if cleanup fails
+			fmt.Printf("Could not delete namespace %v, %v", ns, err)
+		}
+	}
 })

--- a/test/e2e/session_test.go
+++ b/test/e2e/session_test.go
@@ -22,10 +22,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func check(err error) {
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-}
-
 var _ = Describe("Single debug mode", func() {
 
 	It("Should create a debug session", func() {
@@ -39,8 +35,7 @@ var _ = Describe("Single debug mode", func() {
 
 		By("should list no resources after delete")
 		// Run delete before testing to ensure there are no lingering artifacts
-		err = testutils.Squashctl("utils delete-attachments")
-		check(err)
+		must(testutils.Squashctl("utils delete-attachments"))
 		str, err := testutils.SquashctlOut("utils list-attachments")
 		check(err)
 		validateUtilsListDebugAttachments(str, 0)
@@ -50,10 +45,10 @@ var _ = Describe("Single debug mode", func() {
 		By("should create a demo namespace")
 		_, err = cs.CoreV1().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}})
 		check(err)
+		squashTestNamespaces = append(squashTestNamespaces, testNamespace)
 
 		By("should deploy a demo app")
-		err = testutils.Squashctl(fmt.Sprintf("deploy demo --demo-id %v --demo-namespace1 %v --demo-namespace2 %v", "go-java", testNamespace, testNamespace))
-		check(err)
+		must(testutils.Squashctl(fmt.Sprintf("deploy demo --demo-id %v --demo-namespace1 %v --demo-namespace2 %v", "go-java", testNamespace, testNamespace)))
 
 		By("should find the demo deployment")
 		podName, err := waitForPod(cs, testNamespace, "example-service1")
@@ -66,7 +61,7 @@ var _ = Describe("Single debug mode", func() {
 		fmt.Println(dbgStr)
 
 		By("should have created the required permissions")
-		check(ensurePlankPermissionsWereCreated(cs, plankNamespace))
+		must(ensurePlankPermissionsWereCreated(cs, plankNamespace))
 
 		By("should speak with dlv")
 		ensureDLVServerIsLive(dbgStr)

--- a/test/e2e/session_test.go
+++ b/test/e2e/session_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	gokubeutils "github.com/solo-io/go-utils/kubeutils"
 	"github.com/solo-io/squash/pkg/config"
 	sqOpts "github.com/solo-io/squash/pkg/options"
 	"github.com/solo-io/squash/pkg/utils"
@@ -25,13 +24,8 @@ import (
 var _ = Describe("Single debug mode", func() {
 
 	It("Should create a debug session", func() {
-		plankNamespace := sqOpts.SquashNamespace
-		cs := &kubernetes.Clientset{}
 		By("should get a kube client")
-		restCfg, err := gokubeutils.GetConfig("", "")
-		check(err)
-		cs, err = kubernetes.NewForConfig(restCfg)
-		check(err)
+		cs := MustGetClientset()
 
 		By("should list no resources after delete")
 		// Run delete before testing to ensure there are no lingering artifacts
@@ -61,6 +55,7 @@ var _ = Describe("Single debug mode", func() {
 		fmt.Println(dbgStr)
 
 		By("should have created the required permissions")
+		plankNamespace := sqOpts.SquashNamespace
 		must(ensurePlankPermissionsWereCreated(cs, plankNamespace))
 
 		By("should speak with dlv")

--- a/test/e2e/stub.go
+++ b/test/e2e/stub.go
@@ -1,1 +1,0 @@
-package e2e

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -1,0 +1,30 @@
+package e2e_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	gokubeutils "github.com/solo-io/go-utils/kubeutils"
+	"k8s.io/client-go/kubernetes"
+)
+
+func check(err error) {
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+}
+
+// wrapper around check
+// suggestion: use check(err) for functions that return multiple values
+// suggestion: use must(myFunction()) for functions that return error only
+func must(err error) {
+	check(err)
+}
+
+func MustGetClientset() *kubernetes.Clientset {
+	cs := &kubernetes.Clientset{}
+	By("should get a kube client")
+	restCfg, err := gokubeutils.GetConfig("", "")
+	check(err)
+	cs, err = kubernetes.NewForConfig(restCfg)
+	check(err)
+	return cs
+}


### PR DESCRIPTION
- optional "verbose" flag for extension debugging
- script for pointing extension to a particular version during dev
- cleanup resources after tests
- fix bug in permissions
- better (less verbose) output on demo deploy