### PR TITLE
updated squashctl target to match glooctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,10 @@ push-docs:
 # Squashctl
 #----------------------------------------------------------------------------------
 .PHONY: squashctl
-squashctl: $(OUTPUT_DIR)/squashctl-darwin $(OUTPUT_DIR)/squashctl-linux $(OUTPUT_DIR)/squashctl-windows.exe
+squashctl: $(OUTPUT_DIR)/squashctl $(OUTPUT_DIR)/squashctl-darwin $(OUTPUT_DIR)/squashctl-linux $(OUTPUT_DIR)/squashctl-windows.exe
+
+$(OUTPUT_DIR)/squashctl: $(SRCS)
+	go build -a -tags netgo -ldflags=$(LDFLAGS) -o $@ ./cmd/squashctl
 
 $(OUTPUT_DIR)/squashctl-darwin: $(SRCS)
 	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=0 go build -a -tags netgo -ldflags=$(LDFLAGS) -o $@ ./cmd/squashctl


### PR DESCRIPTION
To make it easier to create a Homebrew formula, it is helpful to create a OS local version of `squashctl` as part of the build.