### PR TITLE
Fix Role Binding for Custom Namespace

### DIFF
--- a/changelog/v0.5.6/fix-custom-namespace-rolebind.yaml
+++ b/changelog/v0.5.6/fix-custom-namespace-rolebind.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: FIX 
+  description: Fix Role Binding for Custom Namespace.
+  issueLink: https://github.com/solo-io/squash/issues/147

--- a/pkg/install/squash.go
+++ b/pkg/install/squash.go
@@ -85,7 +85,7 @@ func InstallSquash(cs *kubernetes.Clientset, namespace, containerRepo, container
 			rbacv1.Subject{
 				Kind:      rbacv1.ServiceAccountKind,
 				Name:      sqOpts.SquashServiceAccountName,
-				Namespace: sqOpts.SquashNamespace,
+				Namespace: namespace,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{


### PR DESCRIPTION
**Major changes:**
- Fix the role binding to use the configured namespace instead of the default one.

closes #147.