### PR TITLE
squashctl refactoring kube client

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1243,6 +1243,7 @@
     "github.com/solo-io/go-utils/cliutils",
     "github.com/solo-io/go-utils/contextutils",
     "github.com/solo-io/go-utils/docsutils",
+    "github.com/solo-io/go-utils/errors",
     "github.com/solo-io/go-utils/githubutils",
     "github.com/solo-io/go-utils/kubeutils",
     "github.com/solo-io/go-utils/versionutils",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1281,6 +1281,7 @@
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/rbac/v1",
+    "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",

--- a/changelog/v0.5.6/refactor-kube-client.yaml
+++ b/changelog/v0.5.6/refactor-kube-client.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Consolidated code to get Kubernetes Context client, and added better error handling.
+    issueLink: https://github.com/solo-io/squash/issues/154

--- a/ci/check-code-and-docs-gen.sh
+++ b/ci/check-code-and-docs-gen.sh
@@ -10,7 +10,7 @@ fi
 
 git init
 git add .
-git commit -m "set up dummy repo for diffing" -q
+git commit -m "set up dummy repo for diffing" -q --allow-empty
 
 git clone https://github.com/solo-io/solo-kit /workspace/gopath/src/github.com/solo-io/solo-kit
 

--- a/contrib/templategen.go
+++ b/contrib/templategen.go
@@ -21,8 +21,8 @@ func main() {
 	}
 	tmpl := template.Must(template.New("versioned").Parse(string(templatetxt)))
 	i := Info{
-		Repo : os.Getenv("SQUASH_REPO"),
-		Version : os.Getenv("SQUASH_VERSION"),
+		Repo:    os.Getenv("SQUASH_REPO"),
+		Version: os.Getenv("SQUASH_VERSION"),
 	}
 	tmpl.Execute(os.Stdout, i)
 

--- a/hack/monitor/main.go
+++ b/hack/monitor/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/solo-io/go-utils/contextutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/squash/pkg/api/v1"
+	v1 "github.com/solo-io/squash/pkg/api/v1"
 	"github.com/solo-io/squash/pkg/utils"
 	"github.com/solo-io/squash/pkg/utils/kubeutils"
 )
@@ -62,7 +62,10 @@ func (m *Monitor) Run() error {
 	el := v1.NewApiEventLoop(emitter, syncer)
 	// run event loop
 	// watch all namespaces
-	namespaces := kubeutils.MustGetNamespaces(nil)
+	namespaces, err := kubeutils.MustGetNamespaces(nil)
+	if err != nil {
+		return err
+	}
 	if customNamespaces == unspecifiedCustomNamespaces {
 		namespaces = strings.Split(customNamespaces, ",")
 	}

--- a/hack/monitor/main.go
+++ b/hack/monitor/main.go
@@ -45,7 +45,7 @@ func NewMonitor() (Monitor, error) {
 	}
 	return Monitor{
 		ctx:      ctx,
-		daClient: daClient,
+		daClient: &daClient,
 	}, nil
 }
 

--- a/pkg/config/squash.go
+++ b/pkg/config/squash.go
@@ -96,7 +96,7 @@ func StartDebugContainer(s Squash, dbt DebugTarget) (*v1.Pod, error) {
 }
 
 // for the debug controller, this function finds the debug target
-// from the squash spec that it recieves
+// from the squash spec that it receives
 // If it is able to find a unique target, it applies the target
 // values to the DebugTarget argument. Otherwise it errors.
 func (s *Squash) ExpectToGetUniqueDebugTargetFromSpec(dbt *DebugTarget) error {

--- a/pkg/config/squash.go
+++ b/pkg/config/squash.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	squashkubeutils "github.com/solo-io/squash/pkg/utils/kubeutils"
 	"io"
 	"os"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	gokubeutils "github.com/solo-io/go-utils/kubeutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	squashv1 "github.com/solo-io/squash/pkg/api/v1"
 	"github.com/solo-io/squash/pkg/debuggers/local"
@@ -396,20 +396,15 @@ func (s *Squash) debugPodFor() (*v1.Pod, error) {
 }
 
 func (s *Squash) getClientSet() kubernetes.Interface {
-	if s.clientset != nil {
-		return s.clientset
+	if s.clientset == nil {
+		cs, err := squashkubeutils.GetKubeClient()
+		if err != nil {
+			panic(err)
+		}
+		s.clientset = cs
 	}
-	restCfg, err := gokubeutils.GetConfig("", "")
-	if err != nil {
-		panic(err)
-	}
-	cs, err := kubernetes.NewForConfig(restCfg)
-	if err != nil {
-		panic(err)
-	}
-	s.clientset = cs
-	return s.clientset
 
+	return s.clientset
 }
 
 // DeletePlankPod deletes the plank pod that was created for the debug session

--- a/pkg/config/squash.go
+++ b/pkg/config/squash.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	squashkubeutils "github.com/solo-io/squash/pkg/utils/kubeutils"
 	"io"
 	"os"
 	"strings"
 	"time"
+
+	squashkubeutils "github.com/solo-io/squash/pkg/utils/kubeutils"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -48,9 +49,7 @@ type Squash struct {
 }
 
 func NewSquashConfig() Squash {
-	s := Squash{}
-	s.clientset = s.getClientSet()
-	return s
+	return Squash{}
 }
 
 type DebugTarget struct {
@@ -59,16 +58,21 @@ type DebugTarget struct {
 }
 
 func StartDebugContainer(s Squash, dbt DebugTarget) (*v1.Pod, error) {
-
 	dbgpod, err := s.debugPodFor()
 	if err != nil {
 		return nil, err
 	}
+
+	cs, err := s.getClientSet()
+	if err != nil {
+		return nil, err
+	}
+
 	// create namespace. ignore errors as it most likely exists and will error
-	s.getClientSet().CoreV1().Namespaces().Create(&v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: s.SquashNamespace}})
+	cs.CoreV1().Namespaces().Create(&v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: s.SquashNamespace}})
 
 	// create debugger pod
-	createdPod, err := s.getClientSet().CoreV1().Pods(s.SquashNamespace).Create(dbgpod)
+	createdPod, err := cs.CoreV1().Pods(s.SquashNamespace).Create(dbgpod)
 	if err != nil {
 		return nil, fmt.Errorf("Could not create pod: %v", err)
 	}
@@ -76,6 +80,7 @@ func StartDebugContainer(s Squash, dbt DebugTarget) (*v1.Pod, error) {
 	if !s.Machine && !s.NoClean {
 		// do not remove the pod on a debug server as it is waiting for a
 		// connection
+		// TODO: handle returned error
 		defer s.deletePod(createdPod)
 	}
 
@@ -110,8 +115,11 @@ func (s *Squash) ExpectToGetUniqueDebugTargetFromSpec(dbt *DebugTarget) error {
 }
 
 func (s *Squash) GetDebugTargetPodFromSpec(dbt *DebugTarget) error {
-	var err error
-	dbt.Pod, err = s.getClientSet().CoreV1().Pods(s.Namespace).Get(s.Pod, meta_v1.GetOptions{})
+	cs, err := s.getClientSet()
+	if err != nil {
+		return err
+	}
+	dbt.Pod, err = cs.CoreV1().Pods(s.Namespace).Get(s.Pod, meta_v1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "fetching pod")
 	}
@@ -237,9 +245,13 @@ func (s *Squash) getDebugAttachment() (*squashv1.DebugAttachment, error) {
 	return intent.GetDebugAttachment(daClient)
 }
 
-func (s *Squash) deletePod(createdPod *v1.Pod) {
+func (s *Squash) deletePod(createdPod *v1.Pod) error {
 	var options meta_v1.DeleteOptions
-	s.getClientSet().CoreV1().Pods(s.Namespace).Delete(createdPod.ObjectMeta.Name, &options)
+	cs, err := s.getClientSet()
+	if err != nil {
+		return err
+	}
+	return cs.CoreV1().Pods(s.Namespace).Delete(createdPod.ObjectMeta.Name, &options)
 }
 
 func (s *Squash) waitForPod(ctx context.Context, createdPod *v1.Pod) <-chan error {
@@ -257,8 +269,13 @@ func (s *Squash) waitForPod(ctx context.Context, createdPod *v1.Pod) <-chan erro
 
 				var options meta_v1.GetOptions
 				options.ResourceVersion = createdPod.ResourceVersion
-				var err error
-				createdPod, err = s.getClientSet().CoreV1().Pods(s.SquashNamespace).Get(name, options)
+
+				cs, err := s.getClientSet()
+				if err != nil {
+					errchan <- err
+					return
+				}
+				createdPod, err = cs.CoreV1().Pods(s.SquashNamespace).Get(name, options)
 
 				if createdPod.Status.Phase == v1.PodPending {
 					if !s.Machine {
@@ -293,8 +310,14 @@ func (s *Squash) waitForPod(ctx context.Context, createdPod *v1.Pod) <-chan erro
 }
 
 func (s *Squash) printError(podName string) error {
+	cs, err := s.getClientSet()
+	if err != nil {
+		return err
+	}
+
 	var options v1.PodLogOptions
-	req := s.getClientSet().Core().Pods(s.Namespace).GetLogs(podName, &options)
+
+	req := cs.CoreV1().Pods(s.Namespace).GetLogs(podName, &options)
 
 	readCloser, err := req.Stream()
 	if err != nil {
@@ -323,7 +346,11 @@ func containerNameFromSpec(debugger string) string {
 func (s *Squash) debugPodFor() (*v1.Pod, error) {
 	it := s.GetIntent()
 	const crisockvolume = "crisock"
-	targetPod, err := s.getClientSet().CoreV1().Pods(it.Pod.Namespace).Get(it.Pod.Name, meta_v1.GetOptions{})
+	cs, err := s.getClientSet()
+	if err != nil {
+		return nil, err
+	}
+	targetPod, err := cs.CoreV1().Pods(it.Pod.Namespace).Get(it.Pod.Name, meta_v1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -395,16 +422,16 @@ func (s *Squash) debugPodFor() (*v1.Pod, error) {
 	return templatePod, nil
 }
 
-func (s *Squash) getClientSet() kubernetes.Interface {
+func (s *Squash) getClientSet() (kubernetes.Interface, error) {
 	if s.clientset == nil {
 		cs, err := squashkubeutils.GetKubeClient()
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 		s.clientset = cs
 	}
 
-	return s.clientset
+	return s.clientset, nil
 }
 
 // DeletePlankPod deletes the plank pod that was created for the debug session
@@ -416,10 +443,16 @@ func (s *Squash) DeletePlankPod() error {
 	if err != nil {
 		return err
 	}
+
 	da, err := intent.GetDebugAttachment(daClient)
 	if err != nil {
 		return err
 	}
 
-	return s.clientset.CoreV1().Pods(s.SquashNamespace).Delete(da.PlankName, &meta_v1.DeleteOptions{})
+	cs, err := s.getClientSet()
+	if err != nil {
+		return err
+	}
+
+	return cs.CoreV1().Pods(s.SquashNamespace).Delete(da.PlankName, &meta_v1.DeleteOptions{})
 }

--- a/pkg/squashctl/app.go
+++ b/pkg/squashctl/app.go
@@ -66,11 +66,9 @@ func App(version string) (*cobra.Command, error) {
 		Short:   "debug microservices with squash",
 		Long:    descriptionUsage,
 		Version: version,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			opts.readConfigValues(&opts.Config)
 			opts.logCmd(cmd, args)
-
-			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// when no sub commands are specified, run w/wo RBAC according to settings
@@ -83,9 +81,9 @@ func App(version string) (*cobra.Command, error) {
 
 	app.SuggestionsMinimumDistance = 1
 	app.AddCommand(
-		opts.DeployCmd(opts),
-		opts.SquashCmd(opts),
-		opts.UtilsCmd(opts),
+		opts.DeployCmd(),
+		opts.SquashCmd(),
+		opts.UtilsCmd(),
 		completionCmd(),
 	)
 

--- a/pkg/squashctl/app.go
+++ b/pkg/squashctl/app.go
@@ -224,7 +224,7 @@ func (o *Options) ensureMinimumSquashConfig() error {
 	if err := o.chooseDebugger(); err != nil {
 		return err
 	}
-	if err := o.GetMissing(); err != nil {
+	if err := o.getMissing(); err != nil {
 		return err
 	}
 	if err := o.ensureLocalPort(&o.Squash.LocalPort); err != nil {
@@ -276,7 +276,7 @@ func (o *Options) detectLang() string {
 	return ""
 }
 
-func (o *Options) GetMissing() error {
+func (o *Options) getMissing() error {
 
 	//	clientset.CoreV1().Namespace().
 	// see if namespace exist, and if not prompt for one.

--- a/pkg/squashctl/config_file.go
+++ b/pkg/squashctl/config_file.go
@@ -34,13 +34,13 @@ func writeDefaultConfigFile(fp string) error {
 // Note on use of config file:
 // - should implement a consistent way of reading all values
 // and harmonizing them with flags
-func (top *Options) readConfigValues(c *Config) error {
+func (o *Options) readConfigValues(c *Config) error {
 	// Only read the config once
-	if top.Internal.ConfigLoaded {
+	if o.Internal.ConfigLoaded {
 		return nil
 	}
 
-	if err := top.prepareViperConfig(); err != nil {
+	if err := o.prepareViperConfig(); err != nil {
 		return err
 	}
 
@@ -49,14 +49,14 @@ func (top *Options) readConfigValues(c *Config) error {
 	c.secureMode = viper.GetBool("secure_mode")
 	c.logCmds = viper.GetBool("log_commands")
 
-	top.Internal.ConfigRead = true
+	o.Internal.ConfigRead = true
 	return nil
 }
 
 // This needs to be called before viper can read any config values
-func (top *Options) prepareViperConfig() error {
+func (o *Options) prepareViperConfig() error {
 	// only load the config once
-	if top.Internal.ConfigLoaded {
+	if o.Internal.ConfigLoaded {
 		return nil
 	}
 	// read config file
@@ -64,7 +64,7 @@ func (top *Options) prepareViperConfig() error {
 	cfgFile := ""
 	if cfgFile != "" {
 		// Use config file from the flag.
-		top.printVerbosef("Reading squash config from %v\n", cfgFile)
+		o.printVerbosef("Reading squash config from %v\n", cfgFile)
 		viper.SetConfigFile(cfgFile)
 	} else {
 		squashDir, err := squashDir()
@@ -77,7 +77,7 @@ func (top *Options) prepareViperConfig() error {
 		squashConfigFile := filepath.Join(squashDir, squashConfigFileName)
 		if _, err := os.Stat(squashConfigFile); err == nil {
 			// path exists
-			top.printVerbosef("Reading squash config from %v\n", squashConfigFile)
+			o.printVerbosef("Reading squash config from %v\n", squashConfigFile)
 		} else {
 			if err := writeDefaultConfigFile(squashConfigFile); err != nil {
 				return err
@@ -90,7 +90,7 @@ func (top *Options) prepareViperConfig() error {
 	if err := viper.ReadInConfig(); err != nil {
 		return fmt.Errorf("Can't read config: %v", err)
 	}
-	top.Internal.ConfigLoaded = true
+	o.Internal.ConfigLoaded = true
 	return nil
 }
 

--- a/pkg/squashctl/deploy.go
+++ b/pkg/squashctl/deploy.go
@@ -12,7 +12,7 @@ import (
 
 var defaultDemoNamespace = "default"
 
-func (o *Options) DeployCmd(top *Options) *cobra.Command {
+func (o *Options) DeployCmd() *cobra.Command {
 	dOpts := &o.DeployOptions
 	cmd := &cobra.Command{
 		Use:   "deploy",

--- a/pkg/squashctl/deploy.go
+++ b/pkg/squashctl/deploy.go
@@ -12,7 +12,7 @@ import (
 
 var defaultDemoNamespace = "default"
 
-func (top *Options) DeployCmd(o *Options) *cobra.Command {
+func (o *Options) DeployCmd(top *Options) *cobra.Command {
 	dOpts := &o.DeployOptions
 	cmd := &cobra.Command{
 		Use:   "deploy",
@@ -20,26 +20,30 @@ func (top *Options) DeployCmd(o *Options) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		top.deployDemoCmd(&dOpts.DemoOptions),
-		top.deploySquashCmd(&dOpts.SquashProcessOptions),
+		o.deployDemoCmd(&dOpts.DemoOptions),
+		o.deploySquashCmd(&dOpts.SquashProcessOptions),
 	)
 
 	return cmd
 }
 
-func (top *Options) deployDemoCmd(demoOpts *DemoOptions) *cobra.Command {
+func (o *Options) deployDemoCmd(demoOpts *DemoOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "demo",
 		Short: "deploy a demo microservice",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := top.ensureDemoDeployOpts(demoOpts); err != nil {
+			if err := o.ensureDemoDeployOpts(demoOpts); err != nil {
+				return err
+			}
+			cs, err := o.getKubeClient()
+			if err != nil {
 				return err
 			}
 			switch demoOpts.DemoId {
 			case demo.DemoGoGo:
-				return demo.DeployGoGo(top.KubeClient, demoOpts.Namespace1, demoOpts.Namespace2)
+				return demo.DeployGoGo(cs, demoOpts.Namespace1, demoOpts.Namespace2)
 			case demo.DemoGoJava:
-				return demo.DeployGoJava(top.KubeClient, demoOpts.Namespace1, demoOpts.Namespace2)
+				return demo.DeployGoJava(cs, demoOpts.Namespace1, demoOpts.Namespace2)
 			default:
 				return fmt.Errorf("Please choose a valid demo option: %v", strings.Join(demo.DemoIds, ", "))
 			}
@@ -53,40 +57,44 @@ func (top *Options) deployDemoCmd(demoOpts *DemoOptions) *cobra.Command {
 	return cmd
 }
 
-func (top *Options) ensureDemoDeployOpts(dOpts *DemoOptions) error {
+func (o *Options) ensureDemoDeployOpts(dOpts *DemoOptions) error {
 	if dOpts.Namespace1 == "" {
-		if top.Squash.Machine {
+		if o.Squash.Machine {
 			dOpts.Namespace1 = defaultDemoNamespace
 		} else {
-			top.chooseAllowedNamespace(&dOpts.Namespace1, "Select a namespace for service 1.")
+			o.chooseAllowedNamespace(&dOpts.Namespace1, "Select a namespace for service 1.")
 		}
 	}
 	if dOpts.Namespace2 == "" {
-		if top.Squash.Machine {
+		if o.Squash.Machine {
 			dOpts.Namespace2 = dOpts.Namespace1
 		} else {
-			top.chooseAllowedNamespace(&dOpts.Namespace2, "Select a namespace for service 2.")
+			o.chooseAllowedNamespace(&dOpts.Namespace2, "Select a namespace for service 2.")
 		}
 	}
 	if dOpts.DemoId == "" {
-		if top.Squash.Machine {
+		if o.Squash.Machine {
 			dOpts.DemoId = defaultDemoNamespace
 		} else {
-			top.chooseString("Choose a demo microservice to deploy", &dOpts.DemoId, demo.DemoIds)
+			o.chooseString("Choose a demo microservice to deploy", &dOpts.DemoId, demo.DemoIds)
 		}
 	}
 	return nil
 }
 
-func (top *Options) deploySquashCmd(spOpts *SquashProcessOptions) *cobra.Command {
+func (o *Options) deploySquashCmd(spOpts *SquashProcessOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "squash",
 		Short: "deploy Squash to cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := top.ensureSquashDeployOpts(spOpts); err != nil {
+			if err := o.ensureSquashDeployOpts(spOpts); err != nil {
 				return err
 			}
-			return install.InstallSquash(top.KubeClient, spOpts.Namespace, top.Squash.DebugContainerRepo, top.Squash.DebugContainerVersion, spOpts.Preview)
+			cs, err := o.getKubeClient()
+			if err != nil {
+				return err
+			}
+			return install.InstallSquash(cs, spOpts.Namespace, o.Squash.DebugContainerRepo, o.Squash.DebugContainerVersion, spOpts.Preview)
 		},
 	}
 	f := cmd.Flags()
@@ -94,7 +102,7 @@ func (top *Options) deploySquashCmd(spOpts *SquashProcessOptions) *cobra.Command
 	f.BoolVar(&spOpts.Preview, "preview", false, "If set, prints Squash installation yaml without installing Squash.")
 	return cmd
 }
-func (top *Options) ensureSquashDeployOpts(dOpts *SquashProcessOptions) error {
+func (o *Options) ensureSquashDeployOpts(dOpts *SquashProcessOptions) error {
 	// TODO(mitchdraft) - interactive mode
 	return nil
 }

--- a/pkg/squashctl/squash.go
+++ b/pkg/squashctl/squash.go
@@ -19,7 +19,7 @@ You can configure squash to use secure mode by setting the secure_mode value
 in your .squash config file.
 `
 
-func (o *Options) SquashCmd(top *Options) *cobra.Command {
+func (o *Options) SquashCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "squash",
 		Short: "manage the squash",

--- a/pkg/squashctl/squash.go
+++ b/pkg/squashctl/squash.go
@@ -19,7 +19,7 @@ You can configure squash to use secure mode by setting the secure_mode value
 in your .squash config file.
 `
 
-func (top *Options) SquashCmd(o *Options) *cobra.Command {
+func (o *Options) SquashCmd(top *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "squash",
 		Short: "manage the squash",
@@ -30,24 +30,28 @@ func (top *Options) SquashCmd(o *Options) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		top.squashStatusCmd(),
-		top.squashDeleteCmd(),
+		o.squashStatusCmd(),
+		o.squashDeleteCmd(),
 	)
 
 	return cmd
 }
 
-func (top *Options) squashStatusCmd() *cobra.Command {
+func (o *Options) squashStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "list status of Squash process",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			nsList, err := kubeutils.GetNamespaces(top.KubeClient)
+			cs, err := o.getKubeClient()
+			if err != nil {
+				return err
+			}
+			nsList, err := kubeutils.GetNamespaces(cs)
 			if err != nil {
 				return err
 			}
 			fmt.Printf("looking for Squash process in namespaces %v\n", strings.Join(nsList, ", "))
-			squashDeployments, err := squashutils.ListSquashDeployments(top.KubeClient, nsList)
+			squashDeployments, err := squashutils.ListSquashDeployments(cs, nsList)
 			if err != nil {
 				return err
 			}
@@ -72,7 +76,7 @@ func (top *Options) squashStatusCmd() *cobra.Command {
 	return cmd
 }
 
-func (top *Options) squashDeleteCmd() *cobra.Command {
+func (o *Options) squashDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "delete Squash processes from your cluster by namespace",
@@ -82,7 +86,11 @@ func (top *Options) squashDeleteCmd() *cobra.Command {
 			}
 			ns := args[0]
 			fmt.Printf("Looking for Squash process in namespace %v\n", ns)
-			squashDeployments, err := squashutils.ListSquashDeployments(top.KubeClient, []string{ns})
+			cs, err := o.getKubeClient()
+			if err != nil {
+				return err
+			}
+			squashDeployments, err := squashutils.ListSquashDeployments(cs, []string{ns})
 			if err != nil {
 				return err
 			}
@@ -92,7 +100,7 @@ func (top *Options) squashDeleteCmd() *cobra.Command {
 				fmt.Println("Found no Squash deployments")
 				return nil
 			default:
-				count, err := squashutils.DeleteSquashDeployments(top.KubeClient, squashDeployments)
+				count, err := squashutils.DeleteSquashDeployments(cs, squashDeployments)
 				if err != nil {
 					return fmt.Errorf("Deleted %v deployments: %v", count, err)
 				}

--- a/pkg/squashctl/types.go
+++ b/pkg/squashctl/types.go
@@ -40,7 +40,6 @@ type Options struct {
 
 func NewOptions() *Options {
 	o := &Options{}
-	o.Squash = config.NewSquashConfig()
 	return o
 }
 

--- a/pkg/squashctl/types.go
+++ b/pkg/squashctl/types.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Options struct {
-	KubeClient *kubernetes.Clientset
+	kubeClient *kubernetes.Clientset
 
 	Url            string
 	Json           bool

--- a/pkg/squashctl/util.go
+++ b/pkg/squashctl/util.go
@@ -37,8 +37,12 @@ func (o *Options) getAllDebugAttachments() (v1.DebugAttachmentList, error) {
 		return v1.DebugAttachmentList{}, err
 	}
 	das := v1.DebugAttachmentList{}
+	daClient, err := o.getDAClient()
+	if err != nil {
+		return v1.DebugAttachmentList{}, err
+	}
 	for _, ns := range watchNamespaces {
-		nsDas, err := o.daClient.List(ns, clients.ListOpts{Ctx: o.ctx})
+		nsDas, err := daClient.List(ns, clients.ListOpts{Ctx: o.ctx})
 		if err != nil {
 			return v1.DebugAttachmentList{}, err
 		}
@@ -109,22 +113,22 @@ func RandKubeNameBytes(n int) string {
 	return strings.Join([]string{firstChar, suffix}, "")
 }
 
-func (top *Options) printVerbose(msg string) {
-	if top.Config.verbose && !top.Squash.Machine {
+func (o *Options) printVerbose(msg string) {
+	if o.Config.verbose && !o.Squash.Machine {
 		fmt.Println(msg)
 	}
 }
 
-func (top *Options) printVerbosef(tmpl string, args ...interface{}) {
-	if top.Config.verbose {
+func (o *Options) printVerbosef(tmpl string, args ...interface{}) {
+	if o.Config.verbose {
 		fmt.Printf(tmpl, args)
 	}
 }
 
 var logFileName = "cmd.log"
 
-func (top *Options) logCmd(cmd *cobra.Command, args []string) {
-	if !top.Config.logCmds {
+func (o *Options) logCmd(cmd *cobra.Command, args []string) {
+	if !o.Config.logCmds {
 		return
 	}
 
@@ -180,7 +184,7 @@ func getFlagSpec(cmd *cobra.Command) string {
 	return str
 }
 
-func (top *Options) chooseString(message string, choice *string, options []string) error {
+func (o *Options) chooseString(message string, choice *string, options []string) error {
 	question := &survey.Select{
 		Message: message,
 		Options: options,

--- a/pkg/squashctl/utilscmd.go
+++ b/pkg/squashctl/utilscmd.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (o *Options) UtilsCmd(top *Options) *cobra.Command {
+func (o *Options) UtilsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "utils",
 		Short:   "call various squash utils",

--- a/pkg/utils/kubeutils/utils.go
+++ b/pkg/utils/kubeutils/utils.go
@@ -66,3 +66,15 @@ func GetNamespaces(clientset *kubernetes.Clientset) ([]string, error) {
 	}
 	return namespaces, nil
 }
+
+func GetKubeClient() (*kubernetes.Clientset, error) {
+	restCfg, err := gokubeutils.GetConfig("", "")
+	if err != nil {
+		return &kubernetes.Clientset{}, err
+	}
+	kubeClient, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return &kubernetes.Clientset{}, err
+	}
+	return kubeClient, nil
+}

--- a/pkg/utils/kubeutils/utils.go
+++ b/pkg/utils/kubeutils/utils.go
@@ -43,11 +43,11 @@ func GetNamespaces(clientset *kubernetes.Clientset) ([]string, error) {
 func GetKubeClient() (*kubernetes.Clientset, error) {
 	restCfg, err := gokubeutils.GetConfig("", "")
 	if err != nil {
-		return &kubernetes.Clientset{}, errors.Wrapf(err, "No Kubernetes context config found; please double check your Kubernetes environment")
+		return &kubernetes.Clientset{}, errors.Wrapf(err, "no Kubernetes context config found; please double check your Kubernetes environment")
 	}
 	kubeClient, err := kubernetes.NewForConfig(restCfg)
 	if err != nil {
-		return &kubernetes.Clientset{}, errors.Wrapf(err, "Error connecting to current Kubernetes Context Host %s; please double check your Kubernetes environment", restCfg.Host)
+		return &kubernetes.Clientset{}, errors.Wrapf(err, "error connecting to current Kubernetes Context Host %s; please double check your Kubernetes environment", restCfg.Host)
 	}
 	return kubeClient, nil
 }

--- a/pkg/utils/kubeutils/utils.go
+++ b/pkg/utils/kubeutils/utils.go
@@ -1,7 +1,7 @@
 package kubeutils
 
 import (
-	"fmt"
+	"github.com/solo-io/go-utils/errors"
 
 	gokubeutils "github.com/solo-io/go-utils/kubeutils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,26 +33,8 @@ func MustGetNamespaces(clientset *kubernetes.Clientset) []string {
 	return nss
 }
 
-func GetPodNamespace(clientset *kubernetes.Clientset, podName string) (string, error) {
-	if podName == "" {
-		return "", fmt.Errorf("no pod name specified")
-	}
-	namespaces, err := GetNamespaces(clientset)
 	if err != nil {
-		return "", err
 	}
-	for _, ns := range namespaces {
-		pods, err := clientset.CoreV1().Pods(ns).List(metav1.ListOptions{})
-		if err != nil {
-			return "", fmt.Errorf("list pods for namespace %v", ns)
-		}
-		for _, pod := range pods.Items {
-			if pod.ObjectMeta.Name == podName {
-				return pod.ObjectMeta.Namespace, nil
-			}
-		}
-	}
-	return "", fmt.Errorf("pod %v not found", podName)
 }
 
 func GetNamespaces(clientset *kubernetes.Clientset) ([]string, error) {

--- a/pkg/utils/kubeutils/utils.go
+++ b/pkg/utils/kubeutils/utils.go
@@ -11,30 +11,21 @@ import (
 // MustGetNamespaces returns a list of all namespaces in a cluster - or panics.
 // If a clientset is passed, it will use that, otherwise it creates one.
 // In the event of any error it will panic.
-func MustGetNamespaces(clientset *kubernetes.Clientset) []string {
+func MustGetNamespaces(clientset *kubernetes.Clientset) ([]string, error) {
 	if clientset == nil {
-		restCfg, err := gokubeutils.GetConfig("", "")
+		cs, err := GetKubeClient()
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
-		cs, err := kubernetes.NewForConfig(restCfg)
-		if err != nil {
-			panic(err)
-		}
-		if err != nil {
-			panic(err)
-		}
+
 		clientset = cs
 	}
+
 	nss, err := GetNamespaces(clientset)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return nss
-}
-
-	if err != nil {
-	}
+	return nss, nil
 }
 
 func GetNamespaces(clientset *kubernetes.Clientset) ([]string, error) {
@@ -52,11 +43,11 @@ func GetNamespaces(clientset *kubernetes.Clientset) ([]string, error) {
 func GetKubeClient() (*kubernetes.Clientset, error) {
 	restCfg, err := gokubeutils.GetConfig("", "")
 	if err != nil {
-		return &kubernetes.Clientset{}, err
+		return &kubernetes.Clientset{}, errors.Wrapf(err, "No Kubernetes context config found; please double check your Kubernetes environment")
 	}
 	kubeClient, err := kubernetes.NewForConfig(restCfg)
 	if err != nil {
-		return &kubernetes.Clientset{}, err
+		return &kubernetes.Clientset{}, errors.Wrapf(err, "Error connecting to current Kubernetes Context Host %s; please double check your Kubernetes environment", restCfg.Host)
 	}
 	return kubeClient, nil
 }

--- a/pkg/utils/kubeutils/utils_test.go
+++ b/pkg/utils/kubeutils/utils_test.go
@@ -30,7 +30,8 @@ var _ = Describe("Get namespaces", func() {
 		cs.CoreV1().Namespaces().Create(newNs)
 
 		// test function
-		ns := kubeutils.MustGetNamespaces(nil)
+		ns, err := kubeutils.MustGetNamespaces(nil)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(len(ns) > 0).To(BeTrue())
 		Expect(ns).To(ContainElement(name))
 


### PR DESCRIPTION
Fixes to allow squashctl to run without a kube context to output version and help information.