### PR TITLE
--container flag corresponds to the container's name, not its image.

### DIFF
--- a/changelog/v0.5.8/squashctl-container.yaml
+++ b/changelog/v0.5.8/squashctl-container.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: FIX
+  description: squashctl's --container flag is now the container's name, not image.
+  issueLink: https://github.com/solo-io/squash/issues/159
+

--- a/pkg/config/squash.go
+++ b/pkg/config/squash.go
@@ -136,7 +136,7 @@ func (s *Squash) GetDebugTargetContainerFromSpec(dbt *DebugTarget) error {
 		}
 	}
 	if dbt.Container == nil {
-		return errors.New(fmt.Sprintf("no such container image: %v", s.Container))
+		return errors.New(fmt.Sprintf("no such container name: %v", s.Container))
 	}
 	return nil
 }

--- a/pkg/config/squash.go
+++ b/pkg/config/squash.go
@@ -130,7 +130,7 @@ func (s *Squash) GetDebugTargetContainerFromSpec(dbt *DebugTarget) error {
 	for _, podContainer := range dbt.Pod.Spec.Containers {
 		log.Debug(podContainer.Image)
 		log.Info(podContainer.Image)
-		if strings.HasPrefix(podContainer.Image, s.Container) {
+		if strings.HasPrefix(podContainer.Name, s.Container) {
 			dbt.Container = &podContainer
 			break
 		}


### PR DESCRIPTION
The `--container` flag on `squashctl` is described as 'Container to debug', which implies to me that it is the _name_ of the container, not the image. 

The code uses that flag's value as `Squash.Container` [here](https://github.com/solo-io/squash/blob/cdc6e2c9aa7c69834d305aa0d72d128b9d470594/pkg/squashctl/app.go#L110). It then sets [DebugTarget.Container](https://github.com/solo-io/squash/blob/8c3d21c6525a6be34f92965209d0a85df06178a0/pkg/config/squash.go#L134) based on `Squash.Container`. The corresponding code for interactive choosing containers are [here](https://github.com/solo-io/squash/blob/8c3d21c6525a6be34f92965209d0a85df06178a0/pkg/squashctl/app.go#L325) and [here](https://github.com/solo-io/squash/blob/8c3d21c6525a6be34f92965209d0a85df06178a0/pkg/squashctl/app.go#L347), both have `Squash.Container` set to the container's name, not its image.
BOT NOTES: 
resolves https://github.com/solo-io/squash/issues/159