### PR TITLE
readme: Readme updated to have link to current envoy filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Please visit [squash.solo.io](https://squash.solo.io) for documentation.
 
 ## Roadmap:
 **Service Mesh**
-  - Squash integrates with [Envoy](https://www.envoyproxy.io). Read about the Squash HTTP filter, now part of Envoy [here](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_filters/squash_filter.html). This allows Squash to open debug sessions as a request flows through a microservice. Support for Istio will be added in 2019.
+  - Squash integrates with [Envoy](https://www.envoyproxy.io). Read about the Squash HTTP filter, now part of Envoy [here](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/squash_filter.html). This allows Squash to open debug sessions as a request flows through a microservice. Support for Istio will be added in 2019.
 
 **Debuggers**
  - We will be adding support to several additional debuggers in early 2019, including gdb, nodejs, and python.

--- a/changelog/v0.5.20/readme-envoylink.yaml
+++ b/changelog/v0.5.20/readme-envoylink.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Update link to envoy filter.


### PR DESCRIPTION
Simple Readme update so that the envoy link is no longer broken.