### PR TITLE
Add issue template and workflow for adding new issues to team boards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. kube apply '...'
+2. curl '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here, e.g.
+- Gloo version
+- Istio version

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,0 +1,22 @@
+---
+name: Docs
+about: Describe this issue template's purpose here.
+title: ''
+labels: documentation
+assignees: ''
+
+---
+
+**Describe the requested changes**
+List the desired changes to be made to the wasm docs.
+
+**Link to any relevant existing docs**
+1. https://docs.solo.io/web-assembly-hub/latest/...
+2. ...
+
+**Browser Information**
+If the change isn't related to content, please include your browser version and any other relevant information 
+(e.g., browser zoom) to help us reproduce docs-related bugs.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/workflows/issue_board.yaml
+++ b/.github/workflows/issue_board.yaml
@@ -1,0 +1,23 @@
+name: issue_board
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+jobs:
+  add-to-project:
+    name: Add Rate Limit issue to Gloo Edge project board
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/solo-io/projects/22
+          github-token: ${{ secrets.ORG_CROSS_REPO }}
+          labeled: enhancement, bug
+          label-operator: OR
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/solo-io/projects/24
+          github-token: ${{ secrets.ORG_CROSS_REPO }}
+          labeled: documentation

--- a/changelog/v0.5.20/issue-automation.yaml
+++ b/changelog/v0.5.20/issue-automation.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add issue template (so all issues get labels) and automation to add issues to team boards.
+    issueLink: https://github.com/solo-io/gloo/issues/6305
+    resolvesIssue: false


### PR DESCRIPTION
This is ongoing work in all of our repos to automatically add issues to our team boards for easier tracking and add issue templates to ensure new issues are labelled.